### PR TITLE
Add alt attirbutes for test docs sprint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1482,36 +1482,36 @@ We are very excited to add Eric Charles to the core team this month!
   ([#8562](https://github.com/jupyterlab/jupyterlab/pull/8562),
   [#8477](https://github.com/jupyterlab/jupyterlab/issues/8477))
 
-<img src="https://user-images.githubusercontent.com/226720/84566070-966daf80-ad6e-11ea-815b-5f48136b524b.gif" class="jp-screenshot">
+<img alt=" " src="https://user-images.githubusercontent.com/226720/84566070-966daf80-ad6e-11ea-815b-5f48136b524b.gif" class="jp-screenshot">
 
 - Adds a visual clue for distinguishing hidden files and folders in
   the file browser window
   ([#8393](https://github.com/jupyterlab/jupyterlab/pull/8393))
 
-<img src="https://user-images.githubusercontent.com/13181907/81358007-3b77d700-90a3-11ea-885c-31628c55744b.png" class="jp-screenshot">
+<img alt=" " src="https://user-images.githubusercontent.com/13181907/81358007-3b77d700-90a3-11ea-885c-31628c55744b.png" class="jp-screenshot">
 
 - Enable horizontal scrolling for toolbars to improve mobile
   experience
   ([#8417](https://github.com/jupyterlab/jupyterlab/pull/8417))
 
-<img src="https://user-images.githubusercontent.com/591645/81733090-bb31e700-9491-11ea-96ab-a4b1695b8e3c.gif" class="jp-screenshot">
+<img alt=" " src="https://user-images.githubusercontent.com/591645/81733090-bb31e700-9491-11ea-96ab-a4b1695b8e3c.gif" class="jp-screenshot">
 
 - Improves the right-click context menu for the file editor
   ([#8425](https://github.com/jupyterlab/jupyterlab/pull/8425))
 
-<img src="https://user-images.githubusercontent.com/25207344/84947222-d8bd2680-b0b7-11ea-98da-e4907f9131ba.png" class="jp-screenshot">
+<img alt=" " src="https://user-images.githubusercontent.com/25207344/84947222-d8bd2680-b0b7-11ea-98da-e4907f9131ba.png" class="jp-screenshot">
 
 - Merge cell attachments when merging cells
   ([#8427](https://github.com/jupyterlab/jupyterlab/pull/8427),
   [#8414](https://github.com/jupyterlab/jupyterlab/issues/8414))
 
-<img src="https://user-images.githubusercontent.com/591645/82072833-97acad80-96d8-11ea-957c-ce006731219b.gif" class="jp-screenshot">
+<img alt=" " src="https://user-images.githubusercontent.com/591645/82072833-97acad80-96d8-11ea-957c-ce006731219b.gif" class="jp-screenshot">
 
 - Add styling for high memory usage warning in status bar with
   nbresuse
   ([#8437](https://github.com/jupyterlab/jupyterlab/pull/8437))
 
-<img src="https://user-images.githubusercontent.com/7725109/82213619-1b150b80-9932-11ea-9a53-570bd82d3d2a.png" class="jp-screenshot">
+<img alt=" " src="https://user-images.githubusercontent.com/7725109/82213619-1b150b80-9932-11ea-9a53-570bd82d3d2a.png" class="jp-screenshot">
 
 - Adds support for Python version 3.10
   ([#8445](https://github.com/jupyterlab/jupyterlab/pull/8445))
@@ -1519,7 +1519,7 @@ We are very excited to add Eric Charles to the core team this month!
   ([#8495](https://github.com/jupyterlab/jupyterlab/pull/8495),
   [#8494](https://github.com/jupyterlab/jupyterlab/issues/8494))
 
-<img src="https://user-images.githubusercontent.com/45380/83218329-c8123400-a13b-11ea-9137-6b91a29dbc08.png" class="jp-screenshot">
+<img alt=" " src="https://user-images.githubusercontent.com/45380/83218329-c8123400-a13b-11ea-9137-6b91a29dbc08.png" class="jp-screenshot">
 
 ### For developers
 
@@ -1634,7 +1634,7 @@ closed.
   notebook toolbar
   ([#8024](https://github.com/jupyterlab/jupyterlab/pull/8024))
 
-<img src="https://raw.githubusercontent.com/jupyterlab/jupyterlab/master/docs/source/getting_started/changelog_restartrunallbutton.png" class="jp-screenshot">
+<img alt=" " src="https://raw.githubusercontent.com/jupyterlab/jupyterlab/master/docs/source/getting_started/changelog_restartrunallbutton.png" class="jp-screenshot">
 
 - Added a context menu item for opening a Markdown editor from the
   Markdown preview
@@ -1758,18 +1758,18 @@ closed.
   ([#7407](https://github.com/jupyterlab/jupyterlab/pull/7407),
   [#7786](https://github.com/jupyterlab/jupyterlab/pull/7786))
 
-<img src="https://raw.githubusercontent.com/jupyterlab/jupyterlab/master/docs/source/getting_started/changelog_celltags.png" class="jp-screenshot">
+<img alt=" " src="https://raw.githubusercontent.com/jupyterlab/jupyterlab/master/docs/source/getting_started/changelog_celltags.png" class="jp-screenshot">
 
 - File info display when hovering on a file in the file browser
   ([#7485](https://github.com/jupyterlab/jupyterlab/pull/7485),
   [#7352](https://github.com/jupyterlab/jupyterlab/issues/7352))
 
-<img src="https://raw.githubusercontent.com/jupyterlab/jupyterlab/master/docs/source/getting_started/changelog_fileinfo.png" class="jp-screenshot">
+<img alt=" " src="https://raw.githubusercontent.com/jupyterlab/jupyterlab/master/docs/source/getting_started/changelog_fileinfo.png" class="jp-screenshot">
 
 - Support for searching outputs in notebooks
   ([#7258](https://github.com/jupyterlab/jupyterlab/pull/7258))
 
-<img src="https://raw.githubusercontent.com/jupyterlab/jupyterlab/master/docs/source/getting_started/changelog_searchoutput.png" class="jp-screenshot">
+<img alt=" " src="https://raw.githubusercontent.com/jupyterlab/jupyterlab/master/docs/source/getting_started/changelog_searchoutput.png" class="jp-screenshot">
 
 - `Ctrl Shift .` and `Ctrl Shift ,` shortcuts move focus to the next
   and previous tab bar in the main area, respectively
@@ -2303,7 +2303,7 @@ in 1.0.0, and other 1.0.x milestones for bugs fixed in patch releases.
 
 ### Find and Replace
 
-<img src="https://raw.githubusercontent.com/jupyterlab/jupyterlab/master/docs/source/getting_started/find.png" class="jp-screenshot">
+<img alt=" " src="https://raw.githubusercontent.com/jupyterlab/jupyterlab/master/docs/source/getting_started/find.png" class="jp-screenshot">
 
 We have added first class support for find and replace across
 JupyterLab. It is currently supported in notebooks and text files and is
@@ -2326,7 +2326,7 @@ extensible for other widgets who wish to support it.
 
 ### Status Bar
 
-<img src="https://raw.githubusercontent.com/jupyterlab/jupyterlab/master/docs/source/getting_started/statusbar.png" class="jp-screenshot">
+<img alt=" " src="https://raw.githubusercontent.com/jupyterlab/jupyterlab/master/docs/source/getting_started/statusbar.png" class="jp-screenshot">
 
 We have integrated the [JupyterLab Status Bar
 package](https://github.com/jupyterlab/jupyterlab-statusbar) package

--- a/docs/source/user/files.rst
+++ b/docs/source/user/files.rst
@@ -15,12 +15,14 @@ The file browser is in the left sidebar Files tab:
 .. image:: images/file_menu_left.png
    :align: center
    :class: jp-screenshot
+   :alt: Alt text here
 
 Many actions on files can also be carried out in the File menu:
 
 .. image:: images/file_menu_top.png
    :align: center
    :class: jp-screenshot
+   :alt: Alt text here
 
 .. _open-file:
 
@@ -87,6 +89,7 @@ directory open.
 .. image:: images/shareable_link.png
    :align: center
    :class: jp-screenshot
+   :alt: Alt text here
 
 .. _file-copy-path:
 
@@ -116,6 +119,7 @@ You can also create new documents or activities using the File menu:
 .. image:: images/file_create_text_file.png
    :align: center
    :class: jp-screenshot
+   :alt: Alt text here
 
 .. _current-directory:
 

--- a/docs/source/user/interface.rst
+++ b/docs/source/user/interface.rst
@@ -18,6 +18,7 @@ cell tools inspector <notebook>`, and the :ref:`tabs list <tabs>`.
 .. image:: images/interface_jupyterlab.png
    :align: center
    :class: jp-screenshot
+   :alt: Alt text here
 
 JupyterLab sessions always reside in a :ref:`workspace <url-workspaces-ui>`.
 Workspaces contain the state of JupyterLab: the files that are currently open,
@@ -62,6 +63,7 @@ and a list of tabs in the main work area:
 .. image:: images/interface_left.png
    :align: center
    :class: jp-screenshot
+   :alt: Alt text here
 
 .. _left-sidebar-toggle:
 
@@ -110,12 +112,14 @@ activities in the main work area:
 .. image:: images/interface_tabs.png
    :align: center
    :class: jp-screenshot
+   :alt: Alt text here
 
 The same information is also available in the Tabs menu:
 
 .. image:: images/interface_tabs_menu.png
    :align: center
    :class: jp-screenshot
+   :alt: Alt text here
 
 .. _tabs-singledocument:
 


### PR DESCRIPTION
<!--
Thanks for contributing to JupyterLab!
Please fill out the following items to submit a pull request.
See the contributing guidelines for more information:
https://github.com/jupyterlab/jupyterlab/blob/master/CONTRIBUTING.md
-->

## References

<!-- Note issue numbers this pull request addresses (should be at least one, see contributing guidelines above). -->

<!-- Note any other pull requests that address this issue and how this pull request is different. -->

This is does not address any existing issues that I am aware of. Sprinting to add alt text to documentation has been mentioned in the [weekly team meetings](https://github.com/jupyterlab/team-compass/issues/117#issuecomment-880060794) and [jupyter/accessibility](https://github.com/jupyter/accessibility/issues/43#issuecomment-845365269).

## Code changes

<!-- Describe the code changes and how they address the issue. -->

Adds alt attributes to images under `CHANGELOG.md`, `interface.rst`, and `files.rst`.

## User-facing changes

<!-- Describe any visual or user interaction changes and how they address the issue. -->

<!-- For visual changes, include before and after screenshots here. -->
Images in the docs under `CHANGELOG.md`, `interface.rst`, and `files.rst`will have descriptions. Alt text supports users who use screen readers as well as those that do not.

## Backwards-incompatible changes

<!-- Describe any backwards-incompatible changes to JupyterLab public APIs. -->

None! ✨ 
